### PR TITLE
Add option `preference` for `VoronoiMesh2D`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -121,7 +121,11 @@ class MeshBase(ABC):
 
         arr = np.full(size, -1, dtype=int)
 
-        if mesh is not None and "CellGroup" in mesh.cell_data and "CellGroup" in mesh.user_dict:
+        if (
+            mesh is not None
+            and "CellGroup" in mesh.cell_data
+            and "CellGroup" in mesh.user_dict
+        ):
             for k, v in mesh.user_dict["CellGroup"].items():
                 if k in self.ignore_groups:
                     continue

--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -105,15 +105,23 @@ class MeshBase(ABC):
 
     def _initialize_group_array(
         self,
-        mesh: pv.StructuredGrid | pv.UnstructuredGrid,
+        mesh_or_size: pv.StructuredGrid | pv.UnstructuredGrid | int,
         groups: dict,
         group: Optional[str | dict[str, Callable]] = None,
         default_group: Optional[str] = None,
     ) -> ArrayLike:
         """Initialize group array."""
-        arr = np.full(mesh.n_cells, -1, dtype=int)
+        if isinstance(mesh_or_size, pv.DataSet):
+            mesh = mesh_or_size
+            size = mesh.n_cells
 
-        if "CellGroup" in mesh.cell_data and "CellGroup" in mesh.user_dict:
+        else:
+            mesh = None
+            size = mesh_or_size
+
+        arr = np.full(size, -1, dtype=int)
+
+        if mesh is not None and "CellGroup" in mesh.cell_data and "CellGroup" in mesh.user_dict:
             for k, v in mesh.user_dict["CellGroup"].items():
                 if k in self.ignore_groups:
                     continue
@@ -122,9 +130,9 @@ class MeshBase(ABC):
                     k, groups
                 )
 
-        if group:
+        if mesh is not None and group:
             if isinstance(group, str):
-                group = {group: np.ones(mesh.n_cells, dtype=bool)}
+                group = {group: np.ones(size, dtype=bool)}
 
             for k, v in group.items():
                 if hasattr(v, "__call__"):
@@ -140,7 +148,7 @@ class MeshBase(ABC):
                 elif isinstance(v, (list, tuple, np.ndarray)) and all(
                     isinstance(x, str) for x in v
                 ):
-                    mask = np.zeros(mesh.n_cells, dtype=bool)
+                    mask = np.zeros(size, dtype=bool)
 
                     for cid in v:
                         mask |= (
@@ -153,7 +161,7 @@ class MeshBase(ABC):
                     mask = np.asanyarray(v)
 
                     if mask.dtype.kind.startswith("i"):
-                        mask_ = np.zeros(mesh.n_cells, dtype=bool)
+                        mask_ = np.zeros(size, dtype=bool)
                         mask_[mask] = True
                         mask = mask_
 

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -273,7 +273,7 @@ def extract_cell_geometry(
 
         return poly
 
-    from .. import get_dimension
+    from .. import get_cell_connectivity, get_dimension
 
     if not remove_empty_cells and "vtkGhostType" in mesh.cell_data:
         mesh = mesh.copy(deep=False)
@@ -281,10 +281,8 @@ def extract_cell_geometry(
 
     ndim = get_dimension(mesh)
     mesh = mesh.cast_to_unstructured_grid()
-
-    offset = mesh.offset
     celltypes = mesh.celltypes
-    connectivity = mesh.cell_connectivity
+    connectivity = get_cell_connectivity(mesh)
 
     if ndim in {1, 2}:
         supported_celltypes = {
@@ -305,23 +303,19 @@ def extract_cell_geometry(
 
         # Generate edge data
         cell_edges = [
-            np.column_stack((connectivity[i1 : i2 - 1], connectivity[i1 + 1 : i2]))
+            np.column_stack((cell[:-1], cell[1:]))
             if celltype in {pv.CellType.LINE, pv.CellType.POLY_LINE}
             else np.column_stack(
                 (
-                    connectivity[i1:i2][[0, 1, 3, 2]],
-                    np.roll(connectivity[i1:i2][[0, 1, 3, 2]], -1),
+                    cell[[0, 1, 3, 2]],
+                    np.roll(cell[[0, 1, 3, 2]], -1),
                 )
             )
             if celltype == pv.CellType.PIXEL
-            else np.column_stack(
-                (connectivity[i1:i2], np.roll(connectivity[i1:i2], -1))
-            )
+            else np.column_stack((cell, np.roll(cell, -1)))
             if not remove_empty_cells or celltype != pv.CellType.EMPTY_CELL
             else []
-            for i, (i1, i2, celltype) in enumerate(
-                zip(offset[:-1], offset[1:], celltypes)
-            )
+            for cell, celltype in zip(connectivity, celltypes)
         ]
 
         poly = get_polydata_from_points_cells(mesh.points, cell_edges, "lines")
@@ -342,74 +336,42 @@ def extract_cell_geometry(
                 poly.cell_data["vtkOriginalCellIds"] = tmp
 
     else:
-        # Generate polyhedral cell faces if any
-        polyhedral_cells = pv.convert_array(mesh.GetFaces())
-
-        if polyhedral_cells is not None:
-            locations = pv.convert_array(mesh.GetFaceLocations())
-            polyhedral_cell_faces = []
-
-            for location in locations:
-                if location == -1:
-                    continue
-
-                n_faces = polyhedral_cells[location]
-                i, cell = location + 1, []
-
-                while len(cell) < n_faces:
-                    n_vertices = polyhedral_cells[i]
-                    cell.append(polyhedral_cells[i + 1 : i + 1 + n_vertices])
-                    i += n_vertices + 1
-
-                polyhedral_cell_faces.append(cell)
-
         # Generate face data
-        if celltypes.min() == celltypes.max():
-            celltype = pv.CellType(celltypes[0]).name
-
-            if celltype == "POLYHEDRON":
-                cell_faces = polyhedral_cell_faces
-
-            else:
-                n_vertices = _celltype_to_n_vertices[celltype]
-                cells = connectivity.reshape(
-                    (connectivity.size // n_vertices, n_vertices)
-                )
-                cell_faces = [
+        if np.ptp(celltypes) == 0:
+            celltype = celltypes[0]
+            cell_faces = (
+                [
                     [
                         face
                         for v in _celltype_to_faces[celltype].values()
                         for face in cell[v]
                     ]
-                    for cell in cells
+                    for cell in connectivity
                 ]
+                if celltype != pv.CellType.POLYHEDRON
+                else connectivity
+            )
 
         else:
-            polyhedron_count, cell_faces = 0, []
+            cell_faces = []
 
-            for i, (i1, i2, celltype) in enumerate(
-                zip(offset[:-1], offset[1:], celltypes)
-            ):
-                celltype = pv.CellType(celltype).name
-
-                if celltype == "POLYHEDRON":
-                    cell_face = polyhedral_cell_faces[polyhedron_count]
-                    polyhedron_count += 1
+            for cell, celltype in zip(connectivity, celltypes):
+                if celltype == pv.CellType.POLYHEDRON:
+                    cell_face = cell
 
                 elif celltype in _celltype_to_faces:
-                    cell = connectivity[i1:i2]
                     cell_face = [
                         face
                         for v in _celltype_to_faces[celltype].values()
                         for face in cell[v]
                     ]
 
-                elif celltype == "EMPTY_CELL":
+                elif celltype == pv.CellType.EMPTY_CELL:
                     cell_face = []
 
                 else:
                     raise NotImplementedError(
-                        f"cells of type '{celltype}' are not supported yet"
+                        f"cells of type '{celltype.name}' are not supported yet"
                     )
 
                 cell_faces.append(cell_face)
@@ -1047,18 +1009,18 @@ def quadraticize(mesh: pv.UnstructuredGrid) -> pv.UnstructuredGrid:
 
 
 _celltype_to_faces = {
-    "TETRA": {
+    pv.CellType.TETRA: {
         "TRIANGLE": np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]]),
     },
-    "PYRAMID": {
+    pv.CellType.PYRAMID: {
         "QUAD": np.array([[0, 3, 2, 1]]),
         "TRIANGLE": np.array([[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]]),
     },
-    "WEDGE": {
+    pv.CellType.WEDGE: {
         "TRIANGLE": np.array([[0, 2, 1], [3, 4, 5]]),
         "QUAD": np.array([[0, 1, 4, 3], [1, 2, 5, 4], [0, 3, 5, 2]]),
     },
-    "HEXAHEDRON": {
+    pv.CellType.HEXAHEDRON: {
         "QUAD": np.array(
             [
                 [0, 3, 2, 1],
@@ -1070,7 +1032,7 @@ _celltype_to_faces = {
             ]
         ),
     },
-    "VOXEL": {
+    pv.CellType.VOXEL: {
         "QUAD": np.array(
             [
                 [0, 2, 3, 1],
@@ -1082,9 +1044,4 @@ _celltype_to_faces = {
             ]
         ),
     },
-}
-
-_celltype_to_n_vertices = {
-    k: np.unique(np.concatenate([face.ravel() for face in v.values()])).size
-    for k, v in _celltype_to_faces.items()
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,20 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
     "numpy >= 1.13.0",
-    "pyvista >= 0.36",
+    "pyvista >= 0.45",
     "scipy >= 0.9",
+    "vtk >= 9.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,10 @@
 from collections.abc import Sequence
 
 import numpy as np
-import packaging.version
 import pytest
 import pyvista as pv
 
 import pvgridder as pvg
-
-
-# Check PyVista version for merge_points compatibility
-PYVISTA_VERSION = packaging.version.parse(pv.__version__)
-MERGE_POINTS_COMPATIBLE = PYVISTA_VERSION <= packaging.version.parse("0.45")
 
 
 # Common fixtures for meshes

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,10 +2,8 @@ from collections.abc import Sequence
 from typing import Literal, Union
 
 import numpy as np
-import packaging.version
 import pytest
 import pyvista as pv
-from conftest import MERGE_POINTS_COMPATIBLE, PYVISTA_VERSION
 
 import pvgridder as pvg
 
@@ -393,14 +391,7 @@ def test_fuse_cells(mesh, cell_ids):
     "mesh_type, axes",
     [
         ("structured", [0, 1, 2]),
-        pytest.param(
-            "unstructured",
-            [None],
-            marks=pytest.mark.skipif(
-                not MERGE_POINTS_COMPATIBLE,
-                reason="PyVista version > 0.45 doesn't support merge_points parameter",
-            ),
-        ),
+        pytest.param("unstructured", [None]),
     ],
 )
 def test_merge_basic(mesh_type, axes):
@@ -472,10 +463,6 @@ def test_merge_basic(mesh_type, axes):
 
 
 @pytest.mark.parametrize("as_lines, reference_point_sum", [(True, 11.0), (False, 11.0)])
-@pytest.mark.skipif(
-    PYVISTA_VERSION < packaging.version.parse("0.45"),
-    reason="PyVista version < 0.45 doesn't fully support this functionality",
-)
 def test_merge_lines_basic(
     multiple_lines_polydata, simple_line, as_lines, reference_point_sum
 ):


### PR DESCRIPTION
- Added: option `preference` for `VoronoiMesh2D` to choose which coordinates to use for background mesh. If `point` and input background mesh is a Delaunay triangulation of its points, then the generated mesh should correspond to the dual of the Delaunay triangulation.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
