### PR TITLE
Better support for holes in polygons

### DIFF
--- a/pvgridder/core/geometric_objects.py
+++ b/pvgridder/core/geometric_objects.py
@@ -392,7 +392,7 @@ def Polygon(
         if isinstance(points, pv.DataSet):
             edges = (
                 split_lines(points, as_lines=False)
-                if isinstance(points, pv.PolyData)
+                if isinstance(points, pv.PolyData) and points.n_lines > 0
                 else extract_boundary_polygons(points, fill=False)
             )
 

--- a/pvgridder/core/voronoi.py
+++ b/pvgridder/core/voronoi.py
@@ -407,9 +407,12 @@ class VoronoiMesh2D(MeshBase):
                 voronoi_points = voronoi_points[~mask]
 
         # Generate boundary polygon
-        boundary = extract_boundary_polygons(self.mesh)[0]
-        boundary = decimate_rdp(boundary)
-        boundary = Polygon(np.delete(boundary.points, self.axis, axis=1))
+        boundary = extract_boundary_polygons(self.mesh, with_holes=True)[0]
+        boundary = [
+            np.delete(decimate_rdp(polygon).points, self.axis, axis=1)
+            for polygon in boundary
+        ]
+        boundary = Polygon(boundary[0], boundary[1:])
 
         # Generate polygonal mesh
         points, cells = [], []

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import itertools
 from collections.abc import Sequence
 from typing import Optional
 
-import itertools
 import numpy as np
 import pyvista as pv
 from numpy.typing import ArrayLike
@@ -148,7 +148,10 @@ def extract_boundary_polygons(
     mesh: pv.DataSet,
     fill: bool = False,
     with_holes: bool = False,
-) -> Sequence[pv.PolyData | pv.UnstructuredGrid] | Sequence[Sequence[pv.PolyData | pv.UnstructuredGrid]]:
+) -> (
+    Sequence[pv.PolyData | pv.UnstructuredGrid]
+    | Sequence[Sequence[pv.PolyData | pv.UnstructuredGrid]]
+):
     """
     Extract boundary edges of a mesh as continuous polylines or polygons.
 
@@ -194,7 +197,9 @@ def extract_boundary_polygons(
             if i in holes or j in holes:
                 continue
 
-            if polygons[i].area > polygons[j].area and polygons[i].contains(polygons[j]):
+            if polygons[i].area > polygons[j].area and polygons[i].contains(
+                polygons[j]
+            ):
                 holes[j] = i
 
         # Group boundary edges and holes
@@ -204,12 +209,19 @@ def extract_boundary_polygons(
             polygons[v].append(edges[k])
 
         polygons = [polygon for polygon in polygons if polygon]
-        polygons = [Polygon(polygon[0], polygon[1:]) for polygon in polygons] if fill else polygons
+        polygons = (
+            [Polygon(polygon[0], polygon[1:]) for polygon in polygons]
+            if fill
+            else polygons
+        )
 
     else:
         polygons = (
             [
-                polygon + pv.PolyData().from_regular_faces(polygon.points, [np.arange(polygon.n_points)])
+                polygon
+                + pv.PolyData().from_regular_faces(
+                    polygon.points, [np.arange(polygon.n_points)]
+                )
                 for polygon in edges
             ]
             if fill

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -166,7 +166,7 @@ def extract_boundary_polygons(
 
     Returns
     -------
-    Sequence[pv.PolyData | pv.UnstructuredGrid] | Sequence[Sequence[pv.PolyData | pv.UnstructuredGrid]]
+    Sequence[pyvista.PolyData | pyvista.UnstructuredGrid] | Sequence[Sequence[pyvista.PolyData | pyvista.UnstructuredGrid]]
         Extracted boundary polylines or polygons.
 
     """

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -527,11 +527,7 @@ def test_offset_polygon(request, mesh_or_points, distance, expected_area_change)
     assert result.n_faces_strict > 0
 
     # Check area change if applicable
-    if (
-        is_polydata
-        and expected_area_change is not None
-        and original_area is not None
-    ):
+    if is_polydata and expected_area_change is not None and original_area is not None:
         result_area = result.compute_cell_sizes()["Area"][0]
 
         if expected_area_change == "increase":


### PR DESCRIPTION
- Added: option `with_holes` in `Polygon()` to group holes with their corresponding boundaries.
- Changed: support holes in background mesh when generating Voronoi mesh.
- Fixed: issue in `Polygon()` due to polydata input mesh with no polyline.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
