### PR TITLE
Downgrade to VTK<9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -487,7 +487,7 @@ def fuse_cells(
     indices = [ind] if np.ndim(ind[0]) == 0 else ind
     mesh = mesh.cast_to_unstructured_grid()
     connectivity = list(get_cell_connectivity(mesh))
-    celltypes = mesh.celltypes
+    celltypes = mesh.celltypes.copy()
     mask = np.ones(mesh.n_cells, dtype=bool)
 
     for ind in indices:

--- a/pvgridder/utils/_properties.py
+++ b/pvgridder/utils/_properties.py
@@ -41,7 +41,7 @@ def get_cell_connectivity(
         # Use PyVista's public API while VTK < 9.4
         # faces = _get_irregular_cells(mesh.GetPolyhedronFaces())
         # locations = _get_irregular_cells(mesh.GetPolyhedronFaceLocations())
-        
+
         def split(arr: Sequence[int]) -> list[Sequence[int]]:
             i = 0
             offsets: list[int] = [0]

--- a/pvgridder/utils/_properties.py
+++ b/pvgridder/utils/_properties.py
@@ -38,8 +38,24 @@ def get_cell_connectivity(
 
     # Generate polyhedral cell faces if any
     if (mesh.celltypes == pv.CellType.POLYHEDRON).any():
-        faces = _get_irregular_cells(mesh.GetPolyhedronFaces())
-        locations = _get_irregular_cells(mesh.GetPolyhedronFaceLocations())
+        # Use PyVista's public API while VTK < 9.4
+        # faces = _get_irregular_cells(mesh.GetPolyhedronFaces())
+        # locations = _get_irregular_cells(mesh.GetPolyhedronFaceLocations())
+        
+        def split(arr: Sequence[int]) -> list[Sequence[int]]:
+            i = 0
+            offsets: list[int] = [0]
+
+            while i < len(arr):
+                offsets.append(int(arr[i]) + 1)
+                i += offsets[-1]
+
+            offsets_ = np.cumsum(offsets)
+
+            return [arr[i1 + 1 : i2] for i1, i2 in zip(offsets_[:-1], offsets_[1:])]
+
+        faces = split(mesh.polyhedron_faces)
+        locations = split(mesh.polyhedron_face_locations)
 
         for cid, location in enumerate(locations):
             if location.size == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy >= 1.13.0",
     "pyvista >= 0.45",
     "scipy >= 0.9",
-    "vtk >= 9.4",
+    "vtk < 9.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -327,7 +327,11 @@ def test_extract_cells_by_dimension(request, mesh, ndim, method, expected_result
         # Example mesh
         pytest.param("well_2d", np.arange(8), id="well_2d"),
         # Example mesh with hidden cells
-        pytest.param("anticline_2d", [[164, 165, 205, 206], [20, 61, 102, 143]], id="anticline_2d"),
+        pytest.param(
+            "anticline_2d",
+            [[164, 165, 205, 206], [20, 61, 102, 143]],
+            id="anticline_2d",
+        ),
     ],
 )
 def test_fuse_cells(request, mesh, cell_ids):
@@ -346,10 +350,15 @@ def test_fuse_cells(request, mesh, cell_ids):
         assert results.n_cells == actual_mesh.n_cells - len(cell_ids) + 1
 
     else:
-        assert results.n_cells == actual_mesh.n_cells - np.concatenate(cell_ids).size + len(cell_ids)
+        assert results.n_cells == actual_mesh.n_cells - np.concatenate(
+            cell_ids
+        ).size + len(cell_ids)
 
     # Check area
-    assert np.allclose(results.compute_cell_sizes()["Area"].sum(), actual_mesh.compute_cell_sizes()["Area"].sum())
+    assert np.allclose(
+        results.compute_cell_sizes()["Area"].sum(),
+        actual_mesh.compute_cell_sizes()["Area"].sum(),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -318,73 +318,38 @@ def test_extract_cells_by_dimension(request, mesh, ndim, method, expected_result
 @pytest.mark.parametrize(
     "mesh, cell_ids",
     [
-        # Basic mesh with adjacent quads
+        # # Basic mesh with adjacent quads
         pytest.param(
-            lambda: pv.UnstructuredGrid(
-                {pv.CellType.QUAD: np.array([[0, 1, 3, 2], [1, 4, 5, 3]])},
-                np.array(
-                    [
-                        [0.0, 0.0, 0.0],
-                        [1.0, 0.0, 0.0],
-                        [0.0, 1.0, 0.0],
-                        [1.0, 1.0, 0.0],
-                        [2.0, 0.0, 0.0],
-                        [2.0, 1.0, 0.0],
-                    ],
-                    dtype=np.float64,
-                ),
-            ),
+            lambda: pv.ImageData(dimensions=(2, 3, 1)),
             [0, 1],
             id="basic_quads",
         ),
-        # Example mesh - will look for fusable cells
-        pytest.param(pvg.examples.load_well_2d, None, id="well_2d"),
+        # Example mesh
+        pytest.param("well_2d", np.arange(8), id="well_2d"),
+        # Example mesh with hidden cells
+        pytest.param("anticline_2d", [[164, 165, 205, 206], [20, 61, 102, 143]], id="anticline_2d"),
     ],
 )
-def test_fuse_cells(mesh, cell_ids):
+def test_fuse_cells(request, mesh, cell_ids):
     """Test cell fusion with different meshes."""
-    # Get the actual mesh (executing the function if it's a callable)
-    actual_mesh = mesh() if callable(mesh) else mesh()
+    if isinstance(mesh, str):
+        actual_mesh = request.getfixturevalue(mesh)
 
-    # For example meshes, find cells with the same group to fuse
-    if cell_ids is None and "CellGroup" in actual_mesh.cell_data:
-        groups = actual_mesh.cell_data["CellGroup"]
-        unique_groups = np.unique(groups)
+    else:
+        actual_mesh = mesh()
 
-        if len(unique_groups) > 1:
-            # Get cells from the first group
-            group_cell_indices = np.where(groups == unique_groups[0])[0]
+    # Fuse cells
+    results = pvg.fuse_cells(actual_mesh, cell_ids)
 
-            if len(group_cell_indices) >= 2:
-                cell_ids = group_cell_indices[:2]
+    # Check number of cells
+    if np.ndim(cell_ids[0]) == 0:
+        assert results.n_cells == actual_mesh.n_cells - len(cell_ids) + 1
 
-    # Skip if we couldn't find valid cell IDs
-    if cell_ids is None:
-        pytest.skip("Could not find suitable cells to fuse")
+    else:
+        assert results.n_cells == actual_mesh.n_cells - np.concatenate(cell_ids).size + len(cell_ids)
 
-    try:
-        # Try to fuse the cells
-        result = pvg.fuse_cells(actual_mesh, cell_ids)
-
-        # Should have fewer cells than before
-        assert result.n_cells < actual_mesh.n_cells
-
-        # Check that the first cell is now a polygon
-        if cell_ids[0] < result.n_cells:
-            assert result.celltypes[cell_ids[0]] == pv.CellType.POLYGON
-
-    except ValueError as e:
-        if "could not fuse not fully connected cells" in str(e):
-            pytest.skip("Cells not fully connected, skipping test")
-
-        elif "could not extract boundary" in str(e).lower():
-            pytest.skip("Could not extract boundary, skipping test")
-
-        else:
-            raise
-
-    except NotImplementedError:
-        pytest.skip("Fuse cells not implemented for this mesh type")
+    # Check area
+    assert np.allclose(results.compute_cell_sizes()["Area"].sum(), actual_mesh.compute_cell_sizes()["Area"].sum())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Changed: temporarily downgrade to VTK<9.4 due to issue with `pyvista.DataSetFilters.extract_cells()` that removes hidden cells (see https://github.com/pyvista/pyvista/issues/7484).
- Fixed: issue due to cell types of input mesh changed to empty cells in `pvgridder.fuse_cells()`.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
