### PR TITLE
Fix error `importlib has no attribute metadata`

### DIFF
--- a/pvgridder/_common.py
+++ b/pvgridder/_common.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import importlib
 from functools import wraps
+from importlib import import_module, metadata
 from typing import Callable, Optional
 
 
@@ -11,10 +11,10 @@ def require_package(name: str, version: Optional[tuple[int]] = None) -> Callable
     def decorator(func: Callable):
         """Decorate function."""
         try:
-            importlib.import_module(name)
+            import_module(name)
 
             if version:
-                package_version = importlib.metadata.version(name)
+                package_version = metadata.version(name)
                 package_version = tuple(map(int, package_version.split(".")))
 
                 if package_version < version:


### PR DESCRIPTION
- Fixed: error due to `importlib` on some configurations.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
