### PR TITLE
Add method `MeshStack3D.add_plane()` and option `plain` to `VoronoiMesh2D.add_circle()`

### DIFF
--- a/pvgridder/core/stack.py
+++ b/pvgridder/core/stack.py
@@ -152,11 +152,11 @@ class MeshStack3D(MeshStackBase):
         Parameters
         ----------
         angles : Sequence[float, float, float]
-            Rotation angles in degrees around the x, y, and z axes.
+            Rotation angles in degrees around the X, Y, and Z axes.
         point : Sequence[float, float, float]
-            Point in space where the plane is located.
+            Coordinates of one point on the plane.
         *args, **kwargs
-            Additional arguments for the `add` method.
+            Additional arguments. See ``pvgridder.MeshStack3D.add`` for details.
 
         Returns
         -------

--- a/pvgridder/core/stack.py
+++ b/pvgridder/core/stack.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from numpy.typing import ArrayLike
 from typing import Optional
 
 import numpy as np
 import pyvista as pv
+from numpy.typing import ArrayLike
 from typing_extensions import Self
 
 from ._base import MeshStackBase
@@ -144,7 +144,7 @@ class MeshStack3D(MeshStackBase):
         angles: Sequence[float, float, float],
         point: Sequence[float, float, float],
         *args,
-        **kwargs
+        **kwargs,
     ) -> Self:
         """
         Add a plane to the stack.
@@ -168,7 +168,7 @@ class MeshStack3D(MeshStackBase):
 
         angles = np.array(angles)
         point = np.asanyarray(point)
-        
+
         angles[self.axis] = 0.0
         rot = Rotation.from_rotvec(angles, degrees=True)
         idx = np.delete(np.arange(3), self.axis)
@@ -177,7 +177,7 @@ class MeshStack3D(MeshStackBase):
             points = np.column_stack((x, y, z))
             points[:, idx] -= point[idx]
             points[:, self.axis] = 0.0
-            
+
             return rot.apply(points, inverse=True)[:, self.axis] + point[self.axis]
 
         return self.add(func, *args, **kwargs)

--- a/pvgridder/core/voronoi.py
+++ b/pvgridder/core/voronoi.py
@@ -165,7 +165,9 @@ class VoronoiMesh2D(MeshBase):
         if plain:
             center = np.zeros(3) if center is None else center
             center = np.insert(center, self.axis, 0.0) if len(center) == 2 else center
-            self.fuse_cells.append(lambda x: np.linalg.norm(x - center, axis=1) < radius)
+            self.fuse_cells.append(
+                lambda x: np.linalg.norm(x - center, axis=1) < radius
+            )
 
         return self
 
@@ -336,7 +338,12 @@ class VoronoiMesh2D(MeshBase):
         """
         from shapely import Polygon, get_coordinates
 
-        from .. import average_points, decimate_rdp, extract_boundary_polygons, fuse_cells
+        from .. import (
+            average_points,
+            decimate_rdp,
+            extract_boundary_polygons,
+            fuse_cells,
+        )
 
         groups = {}
         items = sorted(self.items, key=lambda item: abs(item.priority))

--- a/pvgridder/core/voronoi.py
+++ b/pvgridder/core/voronoi.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Literal, Optional
 
 import numpy as np
@@ -50,6 +50,7 @@ class VoronoiMesh2D(MeshBase):
         self._mesh = mesh.copy()
         self._axis = axis
         self._preference = preference
+        self._fuse_cells = []
         self.mesh.points[:, self.axis] = 0.0
 
     def add(
@@ -96,6 +97,7 @@ class VoronoiMesh2D(MeshBase):
         constraint_radius: Optional[float] = None,
         resolution: Optional[int | ArrayLike] = None,
         center: Optional[ArrayLike] = None,
+        plain: bool = False,
         priority: int = 0,
         group: Optional[str] = None,
     ) -> Self:
@@ -113,6 +115,8 @@ class VoronoiMesh2D(MeshBase):
             subdivisions (in percentage) with respect to the starting angle (0 degree).
         center : ArrayLike, optional
             Center of the circle.
+        plain : bool, default False
+            If True, fuse all cells within the circle into a single cell.
         priority : int, default 0
             Priority of item. Points enclosed in a cell with (strictly) higher
             priority are discarded.
@@ -157,6 +161,11 @@ class VoronoiMesh2D(MeshBase):
 
         else:
             raise ValueError("invalid constraint radius")
+
+        if plain:
+            center = np.zeros(3) if center is None else center
+            center = np.insert(center, self.axis, 0.0) if len(center) == 2 else center
+            self.fuse_cells.append(lambda x: np.linalg.norm(x - center, axis=1) < radius)
 
         return self
 
@@ -327,7 +336,7 @@ class VoronoiMesh2D(MeshBase):
         """
         from shapely import Polygon, get_coordinates
 
-        from .. import average_points, decimate_rdp, extract_boundary_polygons
+        from .. import average_points, decimate_rdp, extract_boundary_polygons, fuse_cells
 
         groups = {}
         items = sorted(self.items, key=lambda item: abs(item.priority))
@@ -445,6 +454,12 @@ class VoronoiMesh2D(MeshBase):
         mesh.cell_data["Y"] = voronoi_points[:, 1]
         mesh.cell_data["Z"] = voronoi_points[:, 2]
 
+        # Fuse cells, if any
+        if self.fuse_cells:
+            points = mesh.cell_centers().points
+            indices = [func(points) for func in self.fuse_cells]
+            mesh = fuse_cells(mesh, indices)
+
         return mesh.clean(tolerance=tolerance, produce_merge_map=False)
 
     def _generate_voronoi_tesselation(
@@ -525,3 +540,8 @@ class VoronoiMesh2D(MeshBase):
     def preference(self) -> Literal["cell", "point"]:
         """Return preference."""
         return self._preference
+
+    @property
+    def fuse_cells(self) -> Sequence[Callable]:
+        """Return list of cells to fuse."""
+        return self._fuse_cells

--- a/pvgridder/utils/_connectivity.py
+++ b/pvgridder/utils/_connectivity.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Optional
-from numpy.typing import ArrayLike
 
 import numpy as np
 import pyvista as pv
+from numpy.typing import ArrayLike
 
 
 def get_neighborhood(

--- a/pvgridder/utils/_connectivity.py
+++ b/pvgridder/utils/_connectivity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Optional
+from numpy.typing import ArrayLike
 
 import numpy as np
 import pyvista as pv

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Sequence
-from typing import Optional
+from typing import Literal, Optional
 
 import numpy as np
 import pyvista as pv
@@ -491,6 +491,8 @@ def fuse_cells(
     mask = np.ones(mesh.n_cells, dtype=bool)
 
     for ind in indices:
+        ind = np.asanyarray(ind)
+        ind = np.flatnonzero(ind) if ind.dtype.kind == "b" else ind
         mesh_ = mesh.extract_cells(ind)
         mask[ind[1:]] = False
 


### PR DESCRIPTION
- Fixed: issue with boolean masks indices arrays in `fuse_cells`.
- Added: method `MeshStack3D.add_plane()` to generate a plane given rotation angles and point on the the plane.
- Added: option `plain` to method `VoronoiMesh2D.add_circle()` to generate a plain circle (i.e., without triangles).

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
