### PR TITLE
Avoid merging in loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -420,6 +420,9 @@ class MeshStackBase(MeshBase):
                     item1.mesh.points[:, self.axis],
                 )
 
+        # Generate submeshes
+        meshes = []
+
         for i, (item1, item2) in enumerate(zip(self.items[:-1], self.items[1:])):
             mesh_a = item1.mesh.copy()
             mesh_a.cell_data["CellGroup"] = self._initialize_group_array(
@@ -442,13 +445,10 @@ class MeshStackBase(MeshBase):
 
             mesh_b.cell_data["StackItem"] = np.full(mesh_b.n_cells, i)
             mesh_b.cell_data["StackSubItem"] = np.repeat(np.arange(nsub), repeats)
+            meshes.append(mesh_b)
 
-            if i > 0:
-                mesh = merge(mesh, mesh_b, self.axis, merge_points=False)
-
-            else:
-                mesh = mesh_b
-
+        # Merge submeshes
+        mesh = merge(meshes, axis=self.axis, merge_points=False)
         mesh.user_dict["CellGroup"] = groups
         _ = mesh.set_active_scalars("CellGroup", preference="cell")
 

--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -441,7 +441,7 @@ class MeshStackBase(MeshBase):
                 nsub, repeats = mesh_b.n_cells // mesh_a.n_cells, mesh_a.n_cells
                 mesh_b.cell_data["vtkOriginalCellIds"] = np.tile(
                     np.arange(mesh_a.n_cells), nsub
-                )
+                ).copy()
 
             mesh_b.cell_data["StackItem"] = np.full(mesh_b.n_cells, i)
             mesh_b.cell_data["StackSubItem"] = np.repeat(np.arange(nsub), repeats)

--- a/pvgridder/core/_helpers.py
+++ b/pvgridder/core/_helpers.py
@@ -395,11 +395,15 @@ def generate_volume_from_two_surfaces(
         # Repeat data
         reps = (perc.size, 1)
         for k, v in surface_a.point_data.items():
-            mesh.point_data[k] = np.tile(v, reps[: v.ndim]).copy()  # random crashes in VTK if not copied
+            mesh.point_data[k] = np.tile(
+                v, reps[: v.ndim]
+            ).copy()  # random crashes in VTK if not copied
 
         reps = (perc.size - 1, 1)
         for k, v in surface_a.cell_data.items():
-            mesh.cell_data[k] = np.tile(v, reps[: v.ndim]).copy()  # random crashes in VTK if not copied
+            mesh.cell_data[k] = np.tile(
+                v, reps[: v.ndim]
+            ).copy()  # random crashes in VTK if not copied
 
     else:
         raise ValueError(f"could not generate volume from {type(surface_a)}")

--- a/pvgridder/core/_helpers.py
+++ b/pvgridder/core/_helpers.py
@@ -203,11 +203,11 @@ def generate_surface_from_two_lines(
     if isinstance(line_a, pv.PolyData):
         reps = (perc.size, 1)
         for k, v in line_a.point_data.items():
-            mesh.point_data[k] = np.tile(v, reps[: v.ndim])
+            mesh.point_data[k] = np.tile(v, reps[: v.ndim]).copy()
 
         reps = (perc.size - 1, 1)
         for k, v in line_a.cell_data.items():
-            mesh.cell_data[k] = np.tile(v, reps[: v.ndim])
+            mesh.cell_data[k] = np.tile(v, reps[: v.ndim]).copy()
 
     # Handle collapsed cells
     if "vtkGhostType" not in mesh.cell_data:
@@ -395,11 +395,11 @@ def generate_volume_from_two_surfaces(
         # Repeat data
         reps = (perc.size, 1)
         for k, v in surface_a.point_data.items():
-            mesh.point_data[k] = np.tile(v, reps[: v.ndim])
+            mesh.point_data[k] = np.tile(v, reps[: v.ndim]).copy()  # random crashes in VTK if not copied
 
         reps = (perc.size - 1, 1)
         for k, v in surface_a.cell_data.items():
-            mesh.cell_data[k] = np.tile(v, reps[: v.ndim])
+            mesh.cell_data[k] = np.tile(v, reps[: v.ndim]).copy()  # random crashes in VTK if not copied
 
     else:
         raise ValueError(f"could not generate volume from {type(surface_a)}")

--- a/pvgridder/core/extrude.py
+++ b/pvgridder/core/extrude.py
@@ -169,11 +169,11 @@ class MeshExtrude(MeshBase):
             nsub = mesh_b.n_cells // mesh_a.n_cells
             mesh_b.cell_data["vtkOriginalCellIds"] = np.tile(
                 np.arange(mesh_a.n_cells), nsub
-            )
+            ).copy()
             mesh_b.cell_data["ExtrudeItem"] = np.full(mesh_b.n_cells, i)
             mesh_b.cell_data["ExtrudeSubItem"] = np.repeat(
                 np.arange(nsub), mesh_a.n_cells
-            )
+            ).copy()
             meshes.append(mesh_b)
 
         # Merge submeshes

--- a/pvgridder/core/extrude.py
+++ b/pvgridder/core/extrude.py
@@ -153,6 +153,9 @@ class MeshExtrude(MeshBase):
 
         groups = {}
 
+        # Generate submeshes
+        meshes = []
+
         for i, (item1, item2) in enumerate(zip(self.items[:-1], self.items[1:])):
             mesh_a = item1.mesh.copy()
             mesh_a.cell_data["CellGroup"] = self._initialize_group_array(
@@ -171,18 +174,15 @@ class MeshExtrude(MeshBase):
             mesh_b.cell_data["ExtrudeSubItem"] = np.repeat(
                 np.arange(nsub), mesh_a.n_cells
             )
+            meshes.append(mesh_b)
 
-            if i > 0:
-                axis = (
-                    self.mesh.dimensions.index(1)
-                    if isinstance(mesh, pv.StructuredGrid)
-                    else None
-                )
-                mesh = merge(mesh, mesh_b, axis, merge_points=False)
-
-            else:
-                mesh = mesh_b
-
+        # Merge submeshes
+        axis = (
+            self.mesh.dimensions.index(1)
+            if isinstance(self.mesh, pv.StructuredGrid)
+            else None
+        )
+        mesh = merge(meshes, axis=axis, merge_points=False)
         mesh.user_dict["CellGroup"] = groups
         _ = mesh.set_active_scalars("CellGroup", preference="cell")
 

--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -641,9 +641,7 @@ def merge(
             mesh_a = mesh
 
     else:
-        mesh = pv.merge(
-            dataset, merge_points=merge_points, main_has_priority=True
-        )
+        mesh = pv.merge(dataset, merge_points=merge_points, main_has_priority=True)
 
     return mesh
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -401,7 +401,7 @@ def test_merge_basic(mesh_type, axes):
 
             try:
                 # Merge along axis
-                result = pvg.merge(grid1, grid2, axis=axis)
+                result = pvg.merge((grid1, grid2), axis=axis)
 
                 # Should be a structured grid with more points along the specified axis
                 assert isinstance(result, pv.StructuredGrid)
@@ -429,7 +429,7 @@ def test_merge_basic(mesh_type, axes):
         )
 
         # Merge unstructured grids - we already know MERGE_POINTS_COMPATIBLE is True at this point
-        result = pvg.merge(grid1, grid2, merge_points=True)
+        result = pvg.merge((grid1, grid2), merge_points=True)
 
         # Should be an unstructured grid with more cells
         assert isinstance(result, pv.UnstructuredGrid)


### PR DESCRIPTION
- Changed: collect submeshes in a list and merge all submeshes in one call.
- Fixed: random VTK errors which seem to be due to setting tiled arrays to point and cell data.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
