### PR TITLE
Replace cell data arrays `vtkOriginalCellIds` and `StackSubItem` with `ColumnId` and `LayerId`

### DIFF
--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -434,6 +434,7 @@ class MeshStackBase(MeshBase):
 
         # Generate submeshes
         meshes = []
+        n_layers = 0
 
         for i, (item1, item2) in enumerate(zip(self.items[:-1], self.items[1:])):
             mesh_a = item1.mesh.copy()
@@ -455,9 +456,12 @@ class MeshStackBase(MeshBase):
                     np.arange(mesh_a.n_cells), nsub
                 ).copy()
 
+            mesh_b.cell_data["LayerId"] = np.repeat(
+                np.arange(nsub) + n_layers, repeats
+            ).copy()
             mesh_b.cell_data["StackItem"] = np.full(mesh_b.n_cells, i)
-            mesh_b.cell_data["StackSubItem"] = np.repeat(np.arange(nsub), repeats)
             meshes.append(mesh_b)
+            n_layers += nsub
 
         # Merge submeshes
         mesh = merge(meshes, axis=self.axis, merge_points=False)

--- a/pvgridder/core/extrude.py
+++ b/pvgridder/core/extrude.py
@@ -155,6 +155,7 @@ class MeshExtrude(MeshBase):
 
         # Generate submeshes
         meshes = []
+        n_layers = 0
 
         for i, (item1, item2) in enumerate(zip(self.items[:-1], self.items[1:])):
             mesh_a = item1.mesh.copy()
@@ -170,11 +171,12 @@ class MeshExtrude(MeshBase):
             mesh_b.cell_data["ColumnId"] = np.tile(
                 np.arange(mesh_a.n_cells), nsub
             ).copy()
-            mesh_b.cell_data["ExtrudeItem"] = np.full(mesh_b.n_cells, i)
-            mesh_b.cell_data["ExtrudeSubItem"] = np.repeat(
-                np.arange(nsub), mesh_a.n_cells
+            mesh_b.cell_data["LayerId"] = np.repeat(
+                np.arange(nsub) + n_layers, mesh_a.n_cells
             ).copy()
+            mesh_b.cell_data["ExtrudeItem"] = np.full(mesh_b.n_cells, i)
             meshes.append(mesh_b)
+            n_layers += nsub
 
         # Merge submeshes
         axis = (


### PR DESCRIPTION
- Changed: replaced cell data array `vtkOriginalCellIds` with `ColumnId` to prevent cell array to be lost when using filters that outputs `vtkOriginalCellIds`.
- Changed: replaced cell data array `StackSubItem` (and `ExtrudeSubItem`) with `LayerId` which is more generic and that would allows to identify a cell using its `ColumnId` and `LayerId`.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
