### PR TITLE
Fix duplicate point issue in `fuse_cells()`

### DIFF
--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -503,9 +503,13 @@ def fuse_cells(
                 raise ValueError("could not fuse not fully connected cells together")
 
             # Find original point IDs of polygon
+            # Select first instance found for each point
             cell = poly[0].cast_to_unstructured_grid()
-            ids = np.flatnonzero(
-                (cell.points[:, None] == mesh.points).all(axis=-1).any(axis=0)
+            ids = np.array(
+                [
+                    np.flatnonzero(mask)[0]
+                    for mask in (cell.points[:, None] == mesh.points).all(axis=-1)
+                ]
             )
             mesh_points = mesh.points[ids]
             sorted_ids = ids[


### PR DESCRIPTION
- Fixed: duplicate point issue in `fuse_cells()` when input mesh has duplicate points (e.g., due to mesh clean up being performed after cell fusion in `VoronoiMesh2D.generate_mesh()`).

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
