### PR TITLE
Add option `engine` in `pvgridder.Polygon()`

### DIFF
--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -46,12 +46,20 @@ def test_cylindrical_shell_sector():
 
 
 @pytest.mark.parametrize(
-    "shell, holes, ref_area",
+    "shell, holes, engine, ref_area",
     [
-        (pv.Polygon(radius=8.0, n_sides=42), None, 200.3128038269316),
+        (pv.Polygon(radius=8.0, n_sides=42), None, "gmsh", 200.3128038269316),
+        (pv.Polygon(radius=8.0, n_sides=42), None, "occ", 200.3128038269316),
         (
             pv.Polygon(radius=8.0, n_sides=42),
             [pv.Polygon(radius=4.0, n_sides=42)],
+            "gmsh",
+            150.2346028701987,
+        ),
+        (
+            pv.Polygon(radius=8.0, n_sides=42),
+            [pv.Polygon(radius=4.0, n_sides=42)],
+            "occ",
             150.2346028701987,
         ),
         (
@@ -60,17 +68,20 @@ def test_cylindrical_shell_sector():
                 pv.Polygon(radius=4.0, n_sides=21, center=(-5.0, 0.0, 0.0)),
                 pv.Polygon(radius=4.0, n_sides=21, center=(5.0, 0.0, 0.0)),
             ],
+            "occ",
             110.45831838912522,
         ),
     ],
 )
-def test_polygon(shell, holes, ref_area):
+def test_polygon(shell, holes, engine, ref_area):
     """Test polygon geometric object."""
     for celltype in ("polygon", "triangle", "quad"):
         if celltype == "polygon" and holes:
             continue
 
-        mesh = pvg.Polygon(shell.points[:, :2], holes, celltype, optimization="Netgen")
+        mesh = pvg.Polygon(
+            shell.points[:, :2], holes, celltype, optimization="Netgen", engine=engine
+        )
         mesh = mesh.compute_cell_sizes()
         assert np.allclose(np.abs(mesh.cell_data["Area"]).sum(), ref_area)
         assert getattr(pv.CellType, celltype.upper()) in mesh.celltypes


### PR DESCRIPTION
- Added: option `engine` to select `geo` or `occ` engines when creating a polygon. `geo` seems to be more robust but only `occ` handles holes not fully contained by shell.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
