### PR TITLE
Fix merging issue when user_dict is not initialized

### DIFF
--- a/pvgridder/core/merge.py
+++ b/pvgridder/core/merge.py
@@ -30,7 +30,7 @@ class MeshMerge(MeshBase):
         default_group: Optional[str] = None,
         ignore_groups: Optional[Sequence[str]] = None,
     ) -> None:
-        """Initialize a new mesh factory."""
+        """Initialize a new mesh merger."""
         super().__init__(default_group, ignore_groups)
 
     def add(
@@ -39,7 +39,7 @@ class MeshMerge(MeshBase):
         group: Optional[str] = None,
     ) -> Self:
         """
-        Add a new item to factory.
+        Add a new item to merge.
 
         Parameters
         ----------
@@ -55,6 +55,10 @@ class MeshMerge(MeshBase):
 
         """
         mesh = mesh.cast_to_unstructured_grid()
+
+        # Check for existing user_dict
+        if "_PYVISTA_USER_DICT" not in mesh.field_data:
+            mesh.field_data["_PYVISTA_USER_DICT"] = "{}"
 
         # Add group
         item = MeshItem(mesh, group=group)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+import pvgridder as pvg
+
+
+@pytest.mark.parametrize(
+    "mesha, meshb",
+    [
+        pytest.param("structured_grid_3d", "structured_grid_3d", id="structured-grids"),
+        pytest.param(
+            "tetrahedron_grid",
+            "pyramid_grid",
+            id="unstructured-grids",
+        ),
+        pytest.param(
+            "structured_grid_3d",
+            "tetrahedron_grid",
+            id="mixed-grids",
+        ),
+    ],
+)
+def test_mesh_merge(request, mesha, meshb):
+    mesha = request.getfixturevalue(mesha)
+    meshb = request.getfixturevalue(meshb).translate((0.0, 1.0, 2.0))
+    meshc = mesha.translate((0.0, -1.0, -2.0))
+
+    mesha.cell_data["CellGroup"] = np.zeros(mesha.n_cells, dtype=int)
+    meshb.cell_data["CellGroup"] = np.zeros(meshb.n_cells, dtype=int)
+    mesha.user_dict["CellGroup"] = {"A": 0}
+    meshb.user_dict["CellGroup"] = {"B": 0}
+
+    mesh = (
+        pvg.MeshMerge(default_group="C")
+        .add(mesha)
+        .add(meshb)
+        .add(meshc)
+        .generate_mesh()
+    )
+    assert mesh.n_cells == mesha.n_cells + meshb.n_cells + meshc.n_cells
+    assert mesh.user_dict["CellGroup"] == {"A": 0, "B": 1, "C": 2}


### PR DESCRIPTION
- Fixed: issue when merging with PyVista v0.46 due to uninitialized user_dict.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
