### PR TITLE
Add geometric object `pvgridder.CurvedLine()`

### DIFF
--- a/pvgridder/core/__init__.py
+++ b/pvgridder/core/__init__.py
@@ -5,6 +5,7 @@ from .geometric_objects import (
     AnnularSector,
     Annulus,
     Circle,
+    CurvedLine,
     CylindricalShell,
     CylindricalShellSector,
     Polygon,

--- a/tests/test_geometric_objects.py
+++ b/tests/test_geometric_objects.py
@@ -29,6 +29,15 @@ def test_circle():
     assert np.allclose(np.abs(mesh.cell_data["Area"]).sum(), 0.498934534707864)
 
 
+def test_curved_line():
+    """Test curved line geometric object."""
+    mesh = pvg.CurvedLine([1.0, 2.0, 3.0], 42.8, [0.0, 0.0, -1.0], [0.5, 0.5, 0.0], 16)
+    mesh = mesh.compute_cell_sizes()
+    assert np.allclose(mesh.points[0], [1.0, 2.0, 3.0])
+    assert np.allclose(mesh.points.sum(), 54.660583)
+    assert np.allclose(mesh.cell_data["Length"].sum(), 42.8)
+
+
 def test_cylindrical_shell():
     """Test cylindrical shell geometric object."""
     mesh = pvg.CylindricalShell(0.42, 8.0, 8.0, 8, 8)


### PR DESCRIPTION
- Added: new geometric object to generate a curved line given its starting point, its length, an initial direction vector, and an ending direction vector. Use spherical linear interpolation to generate a smooth curve.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
