### PR TITLE
`np.acos` -> `np.arccos`

### DIFF
--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -1117,7 +1117,7 @@ def ray_cast(
         normals = mesh.compute_normals(
             cell_normals=True, point_normals=False
         ).cell_data["Normals"]
-        angles = np.rad2deg(np.acos(np.abs(normals[ids] @ dvec)))
+        angles = np.rad2deg(np.arccos(np.abs(normals[ids] @ dvec)))
         ids = ids[angles < max_angle]
 
         if ids.size == 0:


### PR DESCRIPTION
- Fixed: issue due to `np.acos` being an alias of `np.arccos` introduced in Numpy v2.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
