### PR TITLE
Add option `bottom_up` to `pvgridder.MeshStack2D()` and `pvgridder.MeshStack3D()`

### DIFF
--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -411,7 +411,9 @@ class MeshStackBase(MeshBase):
         return self
 
     def generate_mesh(
-        self, tolerance: float = 1.0e-8
+        self,
+        tolerance: float = 1.0e-8,
+        bottom_up: bool = True,
     ) -> pv.StructuredGrid | pv.UnstructuredGrid:
         """
         Generate mesh by stacking all items.
@@ -420,6 +422,8 @@ class MeshStackBase(MeshBase):
         ----------
         tolerance : scalar, default 1.0e-8
             Set merging tolerance of duplicate points (for unstructured grids).
+        bottom_up : bool, default True
+            If True, stack items are assumed to be ordered from bottom to top.
 
         Returns
         -------
@@ -444,6 +448,9 @@ class MeshStackBase(MeshBase):
                 - item1.mesh.points[:, self.axis]
                 - item2.thickness
             )
+
+            if not bottom_up:
+                shift *= -1.0
 
             if item2.priority < item1.priority:
                 item2.mesh.points[:, self.axis] = np.where(

--- a/pvgridder/core/_base.py
+++ b/pvgridder/core/_base.py
@@ -252,6 +252,8 @@ class MeshStackBase(MeshBase):
         Base mesh.
     axis : int, default 2
         Stacking axis.
+    bottom_up : bool, default True
+        If True, assume items are stacked from bottom to top.
     default_group : str, optional
         Default group name.
     ignore_groups : Sequence[str], optional
@@ -270,6 +272,7 @@ class MeshStackBase(MeshBase):
         | pv.StructuredGrid
         | pv.UnstructuredGrid,
         axis: int = 2,
+        bottom_up: bool = True,
         default_group: Optional[str] = None,
         ignore_groups: Optional[Sequence[str]] = None,
     ) -> None:
@@ -288,6 +291,7 @@ class MeshStackBase(MeshBase):
         super().__init__(default_group, ignore_groups)
         self._mesh = mesh.copy()
         self._axis = axis
+        self._bottom_up = bottom_up
         self._transition_flag = False
 
     def add(
@@ -308,9 +312,10 @@ class MeshStackBase(MeshBase):
         arg : scalar | Callable | pyvista.DataSet
             New item to add to stack:
 
-             - if scalar, all points of the previous items are translated by *arg* along
-               the stacking axis. If it's the first item of the stack, set the
-               coordinates of the points of the base mesh to *arg* along stacking axis.
+             - if scalar, all points of the previous items are translated by *abs(arg)*
+               along the stacking axis in the direction given by *bottom_up*. If it's
+               the first item of the stack, set the coordinates of the points of the
+               base mesh to *arg* along stacking axis.
 
              - if Callable, must be in the form ``f(x, y, z) -> xyz`` where ``x``,
                ``y``, ``z`` are the coordinates of the points of the base mesh, and
@@ -377,6 +382,8 @@ class MeshStackBase(MeshBase):
                     mesh.points[:, self.axis] = arg
 
                 else:
+                    arg = abs(arg)
+                    arg *= 1.0 if self.bottom_up else -1.0
                     mesh = self.items[-1].mesh.copy()
                     mesh.points[:, self.axis] += arg
 
@@ -413,7 +420,6 @@ class MeshStackBase(MeshBase):
     def generate_mesh(
         self,
         tolerance: float = 1.0e-8,
-        bottom_up: bool = True,
     ) -> pv.StructuredGrid | pv.UnstructuredGrid:
         """
         Generate mesh by stacking all items.
@@ -422,8 +428,6 @@ class MeshStackBase(MeshBase):
         ----------
         tolerance : scalar, default 1.0e-8
             Set merging tolerance of duplicate points (for unstructured grids).
-        bottom_up : bool, default True
-            If True, stack items are assumed to be ordered from bottom to top.
 
         Returns
         -------
@@ -449,7 +453,7 @@ class MeshStackBase(MeshBase):
                 - item2.thickness
             )
 
-            if not bottom_up:
+            if not self.bottom_up:
                 shift *= -1.0
 
             if item2.priority < item1.priority:
@@ -571,3 +575,8 @@ class MeshStackBase(MeshBase):
     def axis(self) -> int:
         """Return stacking axis."""
         return self._axis
+
+    @property
+    def bottom_up(self) -> bool:
+        """Return whether the stacking is from bottom to top."""
+        return self._bottom_up

--- a/pvgridder/core/stack.py
+++ b/pvgridder/core/stack.py
@@ -30,6 +30,8 @@ class MeshStack2D(MeshStackBase):
 
     axis : int, default 2
         Stacking axis.
+    bottom_up : bool, default True
+        If True, assume items are stacked from bottom to top.
     default_group : str, optional
         Default group name.
     ignore_groups : Sequence[str], optional
@@ -44,6 +46,7 @@ class MeshStack2D(MeshStackBase):
         self,
         mesh: pv.PolyData | ArrayLike,
         axis: int = 2,
+        bottom_up: bool = True,
         default_group: Optional[str] = None,
         ignore_groups: Optional[Sequence[str]] = None,
     ) -> None:
@@ -61,7 +64,7 @@ class MeshStack2D(MeshStackBase):
         else:
             lines = split_lines(mesh)[0]
 
-        super().__init__(lines, axis, default_group, ignore_groups)
+        super().__init__(lines, axis, bottom_up, default_group, ignore_groups)
 
     def _extrude(self, *args) -> pv.StructuredGrid:
         """Extrude a line."""
@@ -121,6 +124,8 @@ class MeshStack3D(MeshStackBase):
         Base mesh.
     axis : int, default 2
         Stacking axis.
+    bottom_up : bool, default True
+        If True, assume items are stacked from bottom to top.
     default_group : str, optional
         Default group name.
     ignore_groups : Sequence[str], optional
@@ -138,6 +143,7 @@ class MeshStack3D(MeshStackBase):
         | pv.StructuredGrid
         | pv.UnstructuredGrid,
         axis: int = 2,
+        bottom_up: bool = True,
         default_group: Optional[str] = None,
         ignore_groups: Optional[Sequence[str]] = None,
     ) -> None:
@@ -155,7 +161,7 @@ class MeshStack3D(MeshStackBase):
                 "invalid mesh, input mesh should be a 2D structured grid or an unstructured grid"
             )
 
-        super().__init__(mesh, axis, default_group, ignore_groups)
+        super().__init__(mesh, axis, bottom_up, default_group, ignore_groups)
 
     def add_plane(
         self,


### PR DESCRIPTION
- Added: new class option `bottom_up` to define stacking direction. This fixes a bug when negative scalar were passed in method `add()` due to a conflict with `priority`.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
