### PR TITLE
Restrict option `min_length` to lines intersecting mesh in `pvgridder.intersect_polyline()`

### DIFF
--- a/pvgridder/utils/_misc.py
+++ b/pvgridder/utils/_misc.py
@@ -656,7 +656,11 @@ def intersect_polyline(
     def add_point(point: ArrayLike, line_id: int, cell_id: int) -> None:
         """Add a point to the intersection results."""
         if not np.allclose(points[-1], point, atol=tolerance):
-            if np.linalg.norm(point - points[-1]) >= min_length:
+            if (
+                not mesh_entered
+                or mesh_exited
+                or np.linalg.norm(point - points[-1]) >= min_length
+            ):
                 points.append(point)
                 line_ids.append(line_id)
                 cell_ids.append(cell_id)


### PR DESCRIPTION
- Fixed: only apply `min_length` condition to lines intersecting the mesh.

**Reminders**:

-   [x] Run `invoke ruff` to make sure the code follows the style guide,
-   [x] Add tests for new features or tests that would have caught the bug that you're fixing,
-   [x] Write detailed docstrings for all functions, classes and/or methods,
-   [x] If adding new functionality, unit test it and add it to the documentation.
